### PR TITLE
Fix assumption variable in lambda calculus

### DIFF
--- a/src/wk9/l1.tex
+++ b/src/wk9/l1.tex
@@ -9,7 +9,7 @@
     \infer1[$A$]{\Gamma \vdash x:\tau}
 \end{prooftree}
 \begin{prooftree}
-    \hypo{x: \tau, \Gamma \vdash t : \tau}
+    \hypo{x: \sigma, \Gamma \vdash t : \tau}
     \infer1[$\to_I$]{\Gamma \vdash (\lambda x: \sigma. t) : \sigma \to \tau}
 \end{prooftree}
 \begin{prooftree}


### PR DESCRIPTION
The variable in the assumption (left) half of one of the simply-typed lambda calculus rules has a typo. Could you review?